### PR TITLE
Xeno stamina

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -128,6 +128,8 @@
 			adjustBruteLoss(damage)
 		if(BURN)
 			adjustFireLoss(damage)
+		if(STAMINA)
+			adjustStaminaLoss(damage)
 
 	if(updating_health)
 		updatehealth()

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -74,8 +74,8 @@
 
 	var/stamina_loss_adjustment = staminaloss + amount
 	var/health_limit = maxHealth * 2
-	if(stamina_loss_adjustment > health_limit) //If we exceed maxHealth * 2 stamina damage, half of any excess as oxyloss
-		adjustOxyLoss((stamina_loss_adjustment - health_limit) * 0.5)
+	if(stamina_loss_adjustment > health_limit)
+		AdjustParalyzed(stamina_loss_adjustment*0.2)
 
 	staminaloss = clamp(stamina_loss_adjustment, -max_stamina_buffer, health_limit)
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It lets xenos take stamina damage from weapons that inflict it. Does not add additional nonlethal weapons to use against them. 
## Why It's Good For The Game

Opens up nonlethal options against xenos. 
## Changelog
:cl:
add: Xenos can now take stamina damage from sources. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
